### PR TITLE
Test SIMD optimization, don't use

### DIFF
--- a/src/opt_data.rs
+++ b/src/opt_data.rs
@@ -199,3 +199,24 @@ impl<'dom> OptParser<'dom> {
             .collect::<Vec<_>>()
     }
 }
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parse_caches_to_opts() {
+        use crate::search::Source;
+        for source in [
+            Source::NixDarwin,
+            Source::NixOS,
+            Source::HomeManager,
+            Source::HomeManagerNixOS,
+            Source::HomeManagerNixDarwin,
+        ] {
+            let dom =
+                tl::parse(source.cache(), tl::ParserOptions::default()).expect("cache should work");
+            let opts = parse_options(&dom).expect("cache should work");
+            assert!(!opts.is_empty());
+        }
+    }
+}

--- a/src/search.rs
+++ b/src/search.rs
@@ -108,7 +108,7 @@ impl Source {
         }
     }
 
-    fn cache(self) -> &'static str {
+    pub(crate) fn cache(self) -> &'static str {
         match self {
             Self::NixDarwin => &NIX_DARWIN_CACHED_HTML,
             Self::NixOS => &NIXOS_CACHED_HTML,


### PR DESCRIPTION
Benchmarking tl's parsing alone shows that tl/simd is *slightly* slower than the non-simd variant (505 +/- 4ms vs 495 +/- 4ms). Benchmarked by running the test parse_caches_to_opts, which isolates the tl parts of code, compiled in release mode, using hyperfine with 5 warmup runs, on an M2 Mac.

<!-- Please explain the changes you made -->

<!--
Please, make sure:
- you have read the contributing guidelines:
  https://github.com/madsbv/nix-options-search/blob/main/docs/CONTRIBUTING.md
- you have formatted the code using rustfmt:
  https://github.com/rust-lang/rustfmt
- you have checked that all tests pass, by running `cargo test --workspace`
- you have updated the changelog (if needed):
  https://github.com/madsbv/nix-options-search/blob/main/CHANGELOG.md
-->
