### PR TITLE
Rename binary to `nox` for ease of invocation

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,6 +11,10 @@ include = ["src/*", "data/*", "LICENSE-*", "README.md", "CHANGELOG.md"]
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
+[[bin]]
+name = "nox"
+path = "src/main.rs"
+
 [dependencies]
 color-eyre = "0.6.3"
 crossterm = "0.27.0"


### PR DESCRIPTION
<!-- Please explain the changes you made -->

<!--
Please, make sure:
- you have read the contributing guidelines:
  https://github.com/madsbv/nix-options-search/blob/main/docs/CONTRIBUTING.md
- you have formatted the code using rustfmt:
  https://github.com/rust-lang/rustfmt
- you have checked that all tests pass, by running `cargo test --workspace`
- you have updated the changelog (if needed):
  https://github.com/madsbv/nix-options-search/blob/main/CHANGELOG.md
-->
