### PR TITLE
fix: generalize nixos-unstable link fix

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -593,6 +593,30 @@ dependencies = [
 ]
 
 [[package]]
+name = "lazy-regex"
+version = "3.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "191898e17ddee19e60bccb3945aa02339e81edd4a8c50e21fd4d48cdecda7b29"
+dependencies = [
+ "lazy-regex-proc_macros",
+ "once_cell",
+ "regex",
+ "regex-lite",
+]
+
+[[package]]
+name = "lazy-regex-proc_macros"
+version = "3.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c35dc8b0da83d1a9507e12122c80dea71a9c7c613014347392483a83ea593e04"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "regex",
+ "syn",
+]
+
+[[package]]
 name = "lazy_static"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -725,6 +749,7 @@ dependencies = [
  "crossterm 0.29.0",
  "directories",
  "html2text",
+ "lazy-regex",
  "nucleo",
  "open",
  "ratatui",
@@ -991,6 +1016,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "regex"
+version = "1.12.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "843bc0191f75f3e22651ae5f1e72939ab2f72a4bc30fa80a066bd66edefc24d4"
+dependencies = [
+ "aho-corasick",
+ "memchr",
+ "regex-automata",
+ "regex-syntax",
+]
+
+[[package]]
 name = "regex-automata"
 version = "0.4.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1000,6 +1037,12 @@ dependencies = [
  "memchr",
  "regex-syntax",
 ]
+
+[[package]]
+name = "regex-lite"
+version = "0.1.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8d942b98df5e658f56f20d592c7f868833fe38115e65c33003d8cd224b0155da"
 
 [[package]]
 name = "regex-syntax"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,6 +24,7 @@ color-eyre = "0.6.3"
 crossterm = "0.29.0"
 directories = "6.0.0"
 html2text = "0.16.4"
+lazy-regex = { version = "3.4.2", features = ["lite"] }
 nucleo = "0.5.0"
 open = "5.3.3"
 ratatui = "0.29.0"


### PR DESCRIPTION
Near a new stable release of nixos, some nixos-unstable links are broken and require a bit of rewriting. This generalizes that rewriting so it should work for all future releases.

Fixes #108 
