### PR TITLE
chore: bump version number, changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.3.5] - 2025-12-08
+- Fix name of default binary in flake
+- Fix nixos-unstable source links pointing to non-existent future release branches
+
 ## [0.3.4] - 2025-04-05
 - Update nix-darwin source url to nix-darwin.github.io page
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -742,7 +742,7 @@ checksum = "650eef8c711430f1a879fdd01d4745a7deea475becfb90269c06775983bbf086"
 
 [[package]]
 name = "nix-options-search"
-version = "0.3.4"
+version = "0.3.5"
 dependencies = [
  "bitcode",
  "color-eyre",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "nix-options-search"
-version = "0.3.4"
+version = "0.3.5"
 edition = "2021"
 description = "A tool to fuzzy find nix-darwin and nixOS configuration options"
 keywords = ["cli", "utility", "tui", "nix"]


### PR DESCRIPTION
Bump version number for release of version 0.3.5
